### PR TITLE
Fix recursive getObject() call

### DIFF
--- a/src/main/java/net/gtaun/shoebill/event/object/PlayerObjectMovedEvent.java
+++ b/src/main/java/net/gtaun/shoebill/event/object/PlayerObjectMovedEvent.java
@@ -39,6 +39,6 @@ public class PlayerObjectMovedEvent extends ObjectEvent
 	@Override
 	public PlayerObject getObject()
 	{
-		return getObject();
+		return (PlayerObject) super.getObject();
 	}
 }


### PR DESCRIPTION
Recursive calls can only end by throwing StackOverflowErrors
