### PR TITLE
Fix mistakes in exceptions documentation and remove redundant primary constructor keywords in enums

### DIFF
--- a/src/main/java/net/gtaun/shoebill/constant/BulletHitType.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/BulletHitType.kt
@@ -7,7 +7,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class BulletHitType constructor(val value: Int) {
+enum class BulletHitType(val value: Int) {
     NONE(0),
     PLAYER(1),
     VEHICLE(2),

--- a/src/main/java/net/gtaun/shoebill/constant/CameraCutStyle.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/CameraCutStyle.kt
@@ -22,7 +22,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class CameraCutStyle constructor(val value: Int) {
+enum class CameraCutStyle(val value: Int) {
     /**
      * Direct cut
      */

--- a/src/main/java/net/gtaun/shoebill/constant/ClickPlayerSource.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/ClickPlayerSource.kt
@@ -7,7 +7,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class ClickPlayerSource constructor(val value: Int) {
+enum class ClickPlayerSource(val value: Int) {
     SCOREBOARD(0);
 
     companion object : Collectable<ClickPlayerSource>, Findable<Int, ClickPlayerSource> {

--- a/src/main/java/net/gtaun/shoebill/constant/DialogStyle.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/DialogStyle.kt
@@ -22,7 +22,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class DialogStyle constructor(val value: Int) {
+enum class DialogStyle(val value: Int) {
     /**
      * Message box dialog
      */

--- a/src/main/java/net/gtaun/shoebill/constant/DisconnectReason.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/DisconnectReason.kt
@@ -7,7 +7,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class DisconnectReason constructor(val value: Int) {
+enum class DisconnectReason(val value: Int) {
     /**
      * The player timed out, and the disconnect was unwanted.
      */
@@ -39,4 +39,3 @@ enum class DisconnectReason constructor(val value: Int) {
         override fun get(): Collection<DisconnectReason> = VALUES.values
     }
 }
-

--- a/src/main/java/net/gtaun/shoebill/constant/FightStyle.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/FightStyle.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class FightStyle constructor(val value: Int) {
+enum class FightStyle(val value: Int) {
     NORMAL(4),
     BOXING(5),
     KUNGFU(6),

--- a/src/main/java/net/gtaun/shoebill/constant/GameTextStyle.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/GameTextStyle.kt
@@ -7,7 +7,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class GameTextStyle constructor(val value: Int) {
+enum class GameTextStyle(val value: Int) {
     NORMALE_MIDDLE(0),
     NORMAL_BOTTOM_RIGHT(1),
     GHETTO_MIDDLE(2),

--- a/src/main/java/net/gtaun/shoebill/constant/Interior.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/Interior.kt
@@ -8,7 +8,7 @@ import net.gtaun.shoebill.data.Location
  *
  * @author Julian Suhl (Spikes)
  */
-enum class Interior constructor(val buildingName: String, private val interiorId: Int, private val x: Float,
+enum class Interior(val buildingName: String, private val interiorId: Int, private val x: Float,
                                 private val y: Float, private val z: Float) {
     TWENTYFORSEVEN_1("24/7 1", 17, -25.884498f, -185.868988f, 1003.546875f),
     TWENTYFORSEVEN_2("24/7 2", 10, 6.091179f, -29.271898f, 1003.549438f),

--- a/src/main/java/net/gtaun/shoebill/constant/MapIconStyle.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/MapIconStyle.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class MapIconStyle constructor(val value: Int) {
+enum class MapIconStyle(val value: Int) {
     /**
      * Display in the player's local area
      */
@@ -61,4 +61,3 @@ enum class MapIconStyle constructor(val value: Int) {
     }
 
 }
-

--- a/src/main/java/net/gtaun/shoebill/constant/ObjectEditResponse.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/ObjectEditResponse.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class ObjectEditResponse constructor(val value: Int) {
+enum class ObjectEditResponse(val value: Int) {
     /**
      * Player cancelled (ESC)
      */

--- a/src/main/java/net/gtaun/shoebill/constant/ObjectMaterialSize.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/ObjectMaterialSize.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class ObjectMaterialSize constructor(val value: Int) {
+enum class ObjectMaterialSize(val value: Int) {
     SIZE_32x32(10),
     SIZE_64x32(20),
     SIZE_64x64(30),

--- a/src/main/java/net/gtaun/shoebill/constant/ObjectMaterialTextAlign.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/ObjectMaterialTextAlign.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class ObjectMaterialTextAlign constructor(val value: Int) {
+enum class ObjectMaterialTextAlign(val value: Int) {
     LEFT(0),
     CENTER(1),
     RIGHT(2);

--- a/src/main/java/net/gtaun/shoebill/constant/PickupModel.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/PickupModel.kt
@@ -7,7 +7,7 @@ package net.gtaun.shoebill.constant
  * @author Julian Suhl (Spikes)
  * @author Marvin Haschker
  */
-enum class PickupModel constructor(val id: Int) {
+enum class PickupModel(val id: Int) {
     BRIEFCASE(1210),
     MONEY(1212),
     INFORMATION(1239),

--- a/src/main/java/net/gtaun/shoebill/constant/PlayerAttachBone.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/PlayerAttachBone.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class PlayerAttachBone constructor(val value: Int) {
+enum class PlayerAttachBone(val value: Int) {
     /**
      * Not usable (will crash the client)
      */

--- a/src/main/java/net/gtaun/shoebill/constant/PlayerKey.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/PlayerKey.kt
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.StringUtils
  * @author Marvin Haschker
  * @author Meta
  */
-enum class PlayerKey constructor(val value: Int, private val gameTextKeyOnFootRaw: String?,
+enum class PlayerKey(val value: Int, private val gameTextKeyOnFootRaw: String?,
                                  private val gameTextKeyInVehicleRaw: String?) {
 
     ACTION(1, "PED_ANSWER_PHONE", "VEHICLE_FIREWEAPON"),

--- a/src/main/java/net/gtaun/shoebill/constant/PlayerState.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/PlayerState.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class PlayerState constructor(val value: Int) {
+enum class PlayerState(val value: Int) {
     /**
      * Empty (while initializing)
      */

--- a/src/main/java/net/gtaun/shoebill/constant/PlayerVarType.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/PlayerVarType.kt
@@ -7,7 +7,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class PlayerVarType constructor(val value: Int) {
+enum class PlayerVarType(val value: Int) {
     NONE(0),
     INT(1),
     STRING(2),

--- a/src/main/java/net/gtaun/shoebill/constant/RaceCheckpointType.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/RaceCheckpointType.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class RaceCheckpointType constructor(val value: Int) {
+enum class RaceCheckpointType(val value: Int) {
     /**
      * Normal
      */

--- a/src/main/java/net/gtaun/shoebill/constant/RecordType.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/RecordType.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class RecordType constructor(val value: Int) {
+enum class RecordType(val value: Int) {
     NONE(0),
     DRIVER(1),
     ONFOOT(2);

--- a/src/main/java/net/gtaun/shoebill/constant/ServerVarType.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/ServerVarType.kt
@@ -6,7 +6,7 @@ package net.gtaun.shoebill.constant
  *
  * @author Marvin Haschker
  */
-enum class ServerVarType constructor(val value: Int) {
+enum class ServerVarType(val value: Int) {
     NONE(0),
     INTEGER(1),
     STRING(2),

--- a/src/main/java/net/gtaun/shoebill/constant/ShopName.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/ShopName.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class ShopName constructor(val value: String) {
+enum class ShopName(val value: String) {
     /**
      * None
      */

--- a/src/main/java/net/gtaun/shoebill/constant/SkinModel.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/SkinModel.kt
@@ -25,7 +25,7 @@ package net.gtaun.shoebill.constant
  * @author Trojaner25
  * @author Marvin Haschker
  */
-enum class SkinModel constructor(val id: Int, val description: String, val gender: SkinModel.Gender) {
+enum class SkinModel(val id: Int, val description: String, val gender: SkinModel.Gender) {
     CJ(0, "Carl \"CJ\" Johnson", Gender.MALE),
     TRUTH(1, "The Truth", Gender.MALE),
     MACCER(2, "Maccer", Gender.MALE),

--- a/src/main/java/net/gtaun/shoebill/constant/SpecialAction.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/SpecialAction.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class SpecialAction constructor(val value: Int) {
+enum class SpecialAction(val value: Int) {
     /**
      * None
      */

--- a/src/main/java/net/gtaun/shoebill/constant/SpectateMode.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/SpectateMode.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class SpectateMode constructor(val value: Int) {
+enum class SpectateMode(val value: Int) {
     NORMAL(1),
     FIXED(2),
     SIDE(3);

--- a/src/main/java/net/gtaun/shoebill/constant/TextDrawAlign.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/TextDrawAlign.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class TextDrawAlign constructor(val value: Int) {
+enum class TextDrawAlign(val value: Int) {
     LEFT(1),
     CENTER(2),
     RIGHT(3);

--- a/src/main/java/net/gtaun/shoebill/constant/TextDrawFont.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/TextDrawFont.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class TextDrawFont constructor(val value: Int) {
+enum class TextDrawFont(val value: Int) {
     DIPLOMA(0),
     FONT2(1),
     BANK_GOTHIC(2),

--- a/src/main/java/net/gtaun/shoebill/constant/VehicleComponentModel.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/VehicleComponentModel.kt
@@ -7,7 +7,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class VehicleComponentModel constructor(val id: Int, val modelName:
+enum class VehicleComponentModel(val id: Int, val modelName:
 String, val slot: VehicleComponentSlot, val componentName: String, val supportedVehicleIds: IntArray) {
     SPOILER_PRO(1000, "spl_b_mar_m", VehicleComponentSlot.SPOILER, "Pro", intArrayOf(589, 492, 516, 404, 547, 489, 405, 421)),
     SPOILER_WIN(1001, "spl_b_bab_m", VehicleComponentSlot.SPOILER, "Win", intArrayOf(496, 401, 518, 527, 415, 585, 546, 410, 603, 426, 436, 405, 580, 439, 550, 549, 420, 540, 529)),

--- a/src/main/java/net/gtaun/shoebill/constant/VehicleComponentSlot.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/VehicleComponentSlot.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class VehicleComponentSlot constructor(val value: Int) {
+enum class VehicleComponentSlot(val value: Int) {
     /**
      * Spoiler
      */

--- a/src/main/java/net/gtaun/shoebill/constant/VehicleModel.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/VehicleModel.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author Meta
  * @author MK124
  */
-enum class VehicleModel constructor(val id: Int, val modelName: String, val type: VehicleType,
+enum class VehicleModel(val id: Int, val modelName: String, val type: VehicleType,
                                     val seatCount: Int) {
         LANDSTALKER(400, "Landstalker", VehicleType.CAR, 4),
         BRAVURA(401, "Bravura", VehicleType.CAR, 2),

--- a/src/main/java/net/gtaun/shoebill/constant/VehicleModelInfoType.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/VehicleModelInfoType.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class VehicleModelInfoType constructor(val value: Int) {
+enum class VehicleModelInfoType(val value: Int) {
     /**
      * Vehicle size
      */

--- a/src/main/java/net/gtaun/shoebill/constant/WeaponModel.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/WeaponModel.kt
@@ -23,10 +23,10 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class WeaponModel constructor(@JvmField val id: Int,
-                                   @JvmField val slot: WeaponSlot,
-                                   @JvmField val modelId: Int,
-                                   @JvmField val modelName: String) {
+enum class WeaponModel(@JvmField val id: Int,
+                       @JvmField val slot: WeaponSlot,
+                       @JvmField val modelId: Int,
+                       @JvmField val modelName: String) {
     /**
      * Unarmed
      */

--- a/src/main/java/net/gtaun/shoebill/constant/WeaponSkill.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/WeaponSkill.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class WeaponSkill constructor(val value: Int) {
+enum class WeaponSkill(val value: Int) {
     PISTOL(0),
     PISTOL_SILENCED(1),
     DESERT_EAGLE(2),

--- a/src/main/java/net/gtaun/shoebill/constant/WeaponSlot.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/WeaponSlot.kt
@@ -6,7 +6,7 @@ package net.gtaun.shoebill.constant
  *
  * @author BigETI
  */
-enum class WeaponSlot constructor(val slotId: Int, val type: String) {
+enum class WeaponSlot(val slotId: Int, val type: String) {
     INVALID(-1, "Invalid"),
     HAND(0, "Hand"),
     MELEE(1, "Melee"),

--- a/src/main/java/net/gtaun/shoebill/constant/WeaponState.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/WeaponState.kt
@@ -23,7 +23,7 @@ package net.gtaun.shoebill.constant
  * @author MK124
  * @author Marvin Haschker
  */
-enum class WeaponState constructor(val value: Int) {
+enum class WeaponState(val value: Int) {
     UNKNOWN(-1),
     NO_BULLETS(0),
     LAST_BULLET(1),

--- a/src/main/java/net/gtaun/shoebill/constant/Weather.kt
+++ b/src/main/java/net/gtaun/shoebill/constant/Weather.kt
@@ -6,7 +6,7 @@ package net.gtaun.shoebill.constant
  *
  * @author Julian Suhl (Spikes)
  */
-enum class Weather constructor(val id: Int) {
+enum class Weather(val id: Int) {
     EXTRASUNNY_LA(0),
     SUNNY_LA(1),
     EXTRASUNNY_SMOG_LA(2),

--- a/src/main/java/net/gtaun/shoebill/exception/AlreadyExistException.kt
+++ b/src/main/java/net/gtaun/shoebill/exception/AlreadyExistException.kt
@@ -17,7 +17,7 @@
 package net.gtaun.shoebill.exception
 
 /**
- * This exception will be called when something already exists.
+ * This exception will be thrown when something already exists.
  *
  * @author MK124
  * @author Marvin Haschker

--- a/src/main/java/net/gtaun/shoebill/exception/CreationFailedException.kt
+++ b/src/main/java/net/gtaun/shoebill/exception/CreationFailedException.kt
@@ -17,7 +17,7 @@
 package net.gtaun.shoebill.exception
 
 /**
- * This exception will be called when something failed to create.
+ * This exception will be thrown when something failed to create.
  *
  * @author MK124
  * @author Marvin Haschker

--- a/src/main/java/net/gtaun/shoebill/exception/IllegalLengthException.kt
+++ b/src/main/java/net/gtaun/shoebill/exception/IllegalLengthException.kt
@@ -17,7 +17,7 @@
 package net.gtaun.shoebill.exception
 
 /**
- * This exception will be called when something has an invalid length.
+ * This exception will be thrown when something has an invalid length.
  *
  * @author MK124
  * @author Marvin Haschker

--- a/src/main/java/net/gtaun/shoebill/exception/NoGamemodeAssignedException.kt
+++ b/src/main/java/net/gtaun/shoebill/exception/NoGamemodeAssignedException.kt
@@ -17,7 +17,7 @@
 package net.gtaun.shoebill.exception
 
 /**
- * This exception will be called when no gamemode has been assigned to the server.
+ * This exception will be thrown when no gamemode has been assigned to the server.
  *
  * @author MK124
  * @author Marvin Haschker


### PR DESCRIPTION
Exceptions are thrown, not called.  
`constructor` keywords in classes and enums can be omitted if it's primary constructor without visibility modifiers and annotations.