### PR TITLE
Documentation cleanup

### DIFF
--- a/src/main/java/net/gtaun/shoebill/Shoebill.kt
+++ b/src/main/java/net/gtaun/shoebill/Shoebill.kt
@@ -66,7 +66,7 @@ abstract class Shoebill {
     abstract val version: ShoebillVersion
 
     /**
-     * General-use EventManager
+     * General-use EventManager.
      */
     abstract val eventManager: EventManagerRoot
 

--- a/src/main/java/net/gtaun/shoebill/data/Vector2D.kt
+++ b/src/main/java/net/gtaun/shoebill/data/Vector2D.kt
@@ -56,9 +56,9 @@ open class Vector2D : Cloneable {
      */
     open fun set(vector: Vector2D) = set(vector.x, vector.y)
 
-    open fun add(`val`: Float): Vector2D {
-        x += `val`
-        y += `val`
+    open fun add(value: Float): Vector2D {
+        x += value
+        y += value
         return this
     }
 
@@ -68,9 +68,9 @@ open class Vector2D : Cloneable {
         return this
     }
 
-    open operator fun minus(`val`: Float): Vector2D {
-        x -= `val`
-        y -= `val`
+    open operator fun minus(value: Float): Vector2D {
+        x -= value
+        y -= value
         return this
     }
 
@@ -80,9 +80,9 @@ open class Vector2D : Cloneable {
         return this
     }
 
-    open fun mul(`val`: Float): Vector2D {
-        x *= `val`
-        y *= `val`
+    open fun mul(value: Float): Vector2D {
+        x *= value
+        y *= value
         return this
     }
 
@@ -92,9 +92,9 @@ open class Vector2D : Cloneable {
         return this
     }
 
-    open operator fun div(`val`: Float): Vector2D {
-        x /= `val`
-        y /= `val`
+    open operator fun div(value: Float): Vector2D {
+        x /= value
+        y /= value
         return this
     }
 

--- a/src/main/java/net/gtaun/shoebill/data/Vector3D.kt
+++ b/src/main/java/net/gtaun/shoebill/data/Vector3D.kt
@@ -70,9 +70,9 @@ open class Vector3D : Vector2D, Cloneable {
         return Math.sqrt(dx * dx + dy * dy + dz * dz.toDouble()).toFloat()
     }
 
-    override fun add(`val`: Float): Vector3D {
-        super.add(`val`)
-        z += `val`
+    override fun add(value: Float): Vector3D {
+        super.add(value)
+        z += value
         return this
     }
 
@@ -82,9 +82,9 @@ open class Vector3D : Vector2D, Cloneable {
         return this
     }
 
-    override fun minus(`val`: Float): Vector3D {
-        super.minus(`val`)
-        z -= `val`
+    override fun minus(value: Float): Vector3D {
+        super.minus(value)
+        z -= value
         return this
     }
 
@@ -94,9 +94,9 @@ open class Vector3D : Vector2D, Cloneable {
         return this
     }
 
-    override fun mul(`val`: Float): Vector3D {
-        super.mul(`val`)
-        z *= `val`
+    override fun mul(value: Float): Vector3D {
+        super.mul(value)
+        z *= value
         return this
     }
 
@@ -106,9 +106,9 @@ open class Vector3D : Vector2D, Cloneable {
         return this
     }
 
-    override fun div(`val`: Float): Vector3D {
-        super.div(`val`)
-        z /= `val`
+    override fun div(value: Float): Vector3D {
+        super.div(value)
+        z /= value
         return this
     }
 

--- a/src/main/java/net/gtaun/shoebill/event/actor/ActorStreamInEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/actor/ActorStreamInEvent.kt
@@ -8,9 +8,7 @@ import net.gtaun.shoebill.entities.Player
  *
  * @author Marvin Haschker
  * @see [OnActorStreamIn](https://wiki.sa-mp.com/wiki/OnActorStreamIn)
+ *
+ * @property player The player for whom the actor was streamed in.
  */
-class ActorStreamInEvent(actor: Actor,
-                         /**
-                          * The player for whom the actor was streamed in.
-                          */
-                         val player: Player) : ActorEvent(actor)
+class ActorStreamInEvent(actor: Actor, val player: Player) : ActorEvent(actor)

--- a/src/main/java/net/gtaun/shoebill/event/actor/ActorStreamOutEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/actor/ActorStreamOutEvent.kt
@@ -8,9 +8,7 @@ import net.gtaun.shoebill.entities.Player
  *
  * @author Marvin Haschker
  * @see [OnActorStreamOut](https://wiki.sa-mp.com/wiki/OnActorStreamOut)
+ *
+ * @property player The player for whom the Actor was streamed out.
  */
-class ActorStreamOutEvent(actor: Actor,
-                          /**
-                           * The player for whom the Actor was streamed out.
-                           */
-                          val player: Player) : ActorEvent(actor)
+class ActorStreamOutEvent(actor: Actor, val player: Player) : ActorEvent(actor)

--- a/src/main/java/net/gtaun/shoebill/event/amx/AmxCallEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/amx/AmxCallEvent.kt
@@ -8,19 +8,14 @@ import java.util.*
  * This event will be called when an AmxHook has been executed.
  *
  * @author Marvin Haschker
+ *
+ * @property functionName The name of the executed function.
+ * @property parameters The given parameters from the call.
+ * @property returnValue The return value of the call event.
  */
 class AmxCallEvent @JvmOverloads constructor(
-        /**
-         * The name of the executed function.
-         */
         val functionName: String,
-        /**
-         * The given parameters from the call.
-         */
         val parameters: Array<Any>,
-        /**
-         * The return value of the call event.
-         */
         var returnValue: Int = 1) : Event(), Disallowable {
 
     var isDisallowed: Boolean = false

--- a/src/main/java/net/gtaun/shoebill/event/amx/AmxInstanceEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/amx/AmxInstanceEvent.kt
@@ -7,9 +7,7 @@ import net.gtaun.util.event.Event
  * This event is used for all AmxEvents and contains a AmxInstance variable.
  *
  * @author Marvin Haschker
+ *
+ * @property amxInstance The AmxInstance that is affected by this event.
  */
-open class AmxInstanceEvent protected constructor(
-        /**
-         * The AmxInstance that is affected by this event.
-         */
-        val amxInstance: AmxInstance) : Event()
+open class AmxInstanceEvent protected constructor(val amxInstance: AmxInstance) : Event()

--- a/src/main/java/net/gtaun/shoebill/event/checkpoint/CheckpointEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/checkpoint/CheckpointEvent.kt
@@ -21,17 +21,14 @@ import net.gtaun.shoebill.entities.Player
 import net.gtaun.util.event.Event
 
 /**
- * This abstract event is the base class for every Checkpoint event
+ * This abstract event is the base class for every Checkpoint event.
  *
  * @author MK124
  * @author Marvin Haschker
+ *
+ * @property player The associated player for this checkpoint.
+ * @property checkpoint The related checkpoint for this event.
  */
 open class CheckpointEvent protected constructor(
-        /**
-         * The associated player for this checkpoint.
-         */
         val player: Player,
-        /**
-         * The related checkpoint for this event.
-         */
         val checkpoint: Checkpoint) : Event()

--- a/src/main/java/net/gtaun/shoebill/event/checkpoint/RaceCheckpointEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/checkpoint/RaceCheckpointEvent.kt
@@ -25,13 +25,10 @@ import net.gtaun.util.event.Event
  *
  * @author MK124
  * @author Marvin Haschker
+ *
+ * @property player The associated player for this checkpoint.
+ * @property checkpoint The associated RaceCheckpoint for this event.
  */
 open class RaceCheckpointEvent protected constructor(
-        /**
-         * The associated player for this checkpoint
-         */
         val player: Player,
-        /**
-         * The associated RaceCheckpoint for this event.
-         */
         val checkpoint: RaceCheckpoint) : Event()

--- a/src/main/java/net/gtaun/shoebill/event/dialog/DialogCloseEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/dialog/DialogCloseEvent.kt
@@ -25,11 +25,10 @@ import net.gtaun.shoebill.event.dialog.DialogCloseEvent.DialogCloseType
  *
  * @author MK124
  * @author Marvin Haschker
+ *
+ * @property type The type of the dialog response (see [DialogCloseType]).
  */
 class DialogCloseEvent(dialog: DialogId, player: Player,
-                       /**
-                        * The type of the dialog response (see [DialogCloseType]).
-                        */
                        val type: DialogCloseEvent.DialogCloseType) : DialogEvent(dialog, player) {
 
     enum class DialogCloseType {

--- a/src/main/java/net/gtaun/shoebill/event/menu/MenuSelectedEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/menu/MenuSelectedEvent.kt
@@ -24,12 +24,10 @@ import net.gtaun.shoebill.entities.Player
  *
  * @author MK124
  * @author Marvin Haschker
+ *
+ * @property row The row that has been selected by the [player].
  */
-class MenuSelectedEvent(menu: Menu, player: Player,
-                        /**
-                         * The selected row that has been selected by the [player].
-                         */
-                        val row: Int) : MenuEvent(menu, player) {
+class MenuSelectedEvent(menu: Menu, player: Player, val row: Int) : MenuEvent(menu, player) {
 
     /**
      * This method is an alias for the [interrupt] method.

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerClickPlayerEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerClickPlayerEvent.kt
@@ -25,14 +25,12 @@ import net.gtaun.shoebill.entities.Player
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerClickPlayer](https://wiki.sa-mp.com/wiki/OnPlayerClickPlayer)
+ *
+ * @property clickedPlayer The clicked player of this event.
  */
-class PlayerClickPlayerEvent(player: Player,
-                             /**
-                              * The clicked player of this event
-                              */
-                             val clickedPlayer: Player, source: Int) : PlayerEvent(player) {
+class PlayerClickPlayerEvent(player: Player, val clickedPlayer: Player, source: Int) : PlayerEvent(player) {
     /**
-     * The associated ClickPlayerSource the player clicked
+     * The associated ClickPlayerSource the player clicked.
      */
     val source = ClickPlayerSource[source]
 

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerClickPlayerTextDrawEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerClickPlayerTextDrawEvent.kt
@@ -25,12 +25,10 @@ import net.gtaun.shoebill.entities.PlayerTextdraw
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerClickPlayerTextDraw](https://wiki.sa-mp.com/wiki/OnPlayerClickPlayerTextDraw)
+ *
+ * @property playerTextdraw The associated and clicked PlayerTextdraw for this event.
  */
-class PlayerClickPlayerTextDrawEvent(player: Player,
-                                     /**
-                                      * The associated and clicked PlayerTextdraw for this event.
-                                      */
-                                     val playerTextdraw: PlayerTextdraw) : PlayerEvent(player) {
+class PlayerClickPlayerTextDrawEvent(player: Player, val playerTextdraw: PlayerTextdraw) : PlayerEvent(player) {
     /**
      * The current response value
      */

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerClickTextDrawEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerClickTextDrawEvent.kt
@@ -25,12 +25,10 @@ import net.gtaun.shoebill.entities.Textdraw
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerClickTextDraw](https://wiki.sa-mp.com/wiki/OnPlayerClickTextDraw)
+ *
+ * @property textdraw The associated and clicked Textdraw for this event.
  */
-class PlayerClickTextDrawEvent(player: Player,
-                               /**
-                                * The associated and clicked Textdraw for this event.
-                                */
-                               val textdraw: Textdraw) : PlayerEvent(player) {
+class PlayerClickTextDrawEvent(player: Player, val textdraw: Textdraw) : PlayerEvent(player) {
     /**
      * The current response value
      */

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerCommandEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerCommandEvent.kt
@@ -25,12 +25,10 @@ import net.gtaun.util.event.Interruptable
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerCommandText](https://wiki.sa-mp.com/wiki/OnPlayerCommandText)
+ *
+ * @property command The associated command for this event.
  */
-class PlayerCommandEvent(player: Player,
-                         /**
-                          * The associated command for this event.
-                          */
-                         val command: String) : PlayerEvent(player), Interruptable {
+class PlayerCommandEvent(player: Player, val command: String) : PlayerEvent(player), Interruptable {
     /**
      * Returns the current response value
      * @return Current response value

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerDamageActorEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerDamageActorEvent.kt
@@ -10,23 +10,14 @@ import net.gtaun.shoebill.entities.Player
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerDamageActor](https://wiki.sa-mp.com/wiki/OnPlayerDamageActor)
+ *
+ * @property actor The associated Actor for this event.
+ * @property amount The associated amount of damage for this event.
+ * @property weapon The associated WeaponModel an issuer used for this event.
+ * @property bodypart The associated id of hit bodypart for this event.
  */
 class PlayerDamageActorEvent(player: Player,
-                             /**
-                              * The associated Actor for this event.
-                              */
                              val actor: Actor,
-                             /**
-                              * The associated amount of damage for this event.
-                              */
                              val amount: Float,
-                             /**
-                              * The associated WeaponModel an issuer used for this event.
-                              */
                              val weapon: WeaponModel,
-                             /**
-                              * The associated id of hit bodypart for this event.
-                              */
-                             val bodypart: Int) : PlayerEvent(player) {
-
-}
+                             val bodypart: Int) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerDeathEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerDeathEvent.kt
@@ -26,14 +26,10 @@ import net.gtaun.util.event.Interruptable
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerDeath](https://wiki.sa-mp.com/wiki/OnPlayerDeath)
+ *
+ * @property killer The associated killer for this event.
+ * @property reason The associated WeaponModel the killer used for this event.
  */
 class PlayerDeathEvent(player: Player,
-                       /**
-                        * The associated killer for this event.
-                        */
                        val killer: Player?,
-                       /**
-                        * The associated WeaponModel the killer used for this event.
-                        */
-                       val reason: WeaponModel) : PlayerEvent(player), Interruptable {
-}
+                       val reason: WeaponModel) : PlayerEvent(player), Interruptable

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerDisconnectEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerDisconnectEvent.kt
@@ -26,11 +26,10 @@ import net.gtaun.util.event.Disallowable
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerDisconnect](https://wiki.sa-mp.com/wiki/OnPlayerDisconnect)
+ *
+ * @property reason The associated DisconnectReason for this event.
  */
 class PlayerDisconnectEvent(player: Player,
-                            /**
-                             * The associated DisconnectReason for this event.
-                             */
                             val reason: DisconnectReason) : PlayerEvent(player), Disallowable {
 
     /**

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerEditAttachedObjectEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerEditAttachedObjectEvent.kt
@@ -26,25 +26,16 @@ import net.gtaun.shoebill.entities.PlayerAttach.PlayerAttachSlot
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerEditAttachedObject](https://wiki.sa-mp.com/wiki/OnPlayerEditAttachedObject)
+ *
+ * @property slot The associated slot for whom player the testing was attached for this event.
+ * @property response The response of the event.
+ * @property offset The associated offset for this event.
+ * @property rotation The associated rotation for this event.
+ * @property scale The associated scale for this event.
  */
 class PlayerEditAttachedObjectEvent(player: Player,
-                                    /**
-                                     * The associated slot for whom player the testing was attached for this event.
-                                     */
                                     val slot: PlayerAttachSlot,
-                                    /**
-                                     * The response of the event.
-                                     */
                                     val response: Int,
-                                    /**
-                                     * The associated offset for this event.
-                                     */
                                     val offset: Vector3D,
-                                    /**
-                                     * The associated rotation for this event.
-                                     */
                                     val rotation: Vector3D,
-                                    /**
-                                     * The associated scale for this event.
-                                     */
                                     val scale: Vector3D) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerEditObjectEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerEditObjectEvent.kt
@@ -28,21 +28,14 @@ import net.gtaun.shoebill.entities.SampObject
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerEditObject](https://wiki.sa-mp.com/wiki/OnPlayerEditObject)
+ *
+ * @property object The associated SampObject for this event.
+ * @property editResponse The associated returned testing for this event.
+ * @property newLocation The associated new Location for this event.
+ * @property newRotation The associated new rotation for this event.
  */
 class PlayerEditObjectEvent(player: Player,
-                            /**
-                             * The associated SampObject for this event.
-                             */
                             val `object`: SampObject,
-                            /**
-                             * The associated returned testing for this event.
-                             */
                             val editResponse: ObjectEditResponse,
-                            /**
-                             * The associated new Location for this event.
-                             */
                             val newLocation: Location,
-                            /**
-                             * The associated new rotat`ion for this event.
-                             */
                             val newRotation: Vector3D) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerEditPlayerObjectEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerEditPlayerObjectEvent.kt
@@ -28,21 +28,14 @@ import net.gtaun.shoebill.entities.PlayerObject
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerEditPlayerObject](https://wiki.sa-mp.com/wiki/OnPlayerEditPlayerObject)
+ *
+ * @property object The associated PlayerObject for this event.
+ * @property editResponse The associated returned testing for this event.
+ * @property newLocation The associated new Location for this event.
+ * @property newRotation The associated new rotation for this event.
  */
 class PlayerEditPlayerObjectEvent(player: Player,
-                                  /**
-                                   * The associated PlayerObject for this event.
-                                   */
                                   val `object`: PlayerObject,
-                                  /**
-                                   * The associated returned testing for this event.
-                                   */
                                   val editResponse: ObjectEditResponse,
-                                  /**
-                                   * The associated new Location for this event.
-                                   */
                                   val newLocation: Location,
-                                  /**
-                                   * The associated new rotation for this event.
-                                   */
                                   val newRotation: Vector3D) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerEnterExitModShopEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerEnterExitModShopEvent.kt
@@ -24,13 +24,10 @@ import net.gtaun.shoebill.entities.Player
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerEnterExitModShop](https://wiki.sa-mp.com/wiki/OnPlayerEnterExitModShop)
+ *
+ * @property enterExit The associated value for this event.
+ * @property interiorId The associated id of interior for this event.
  */
 class PlayerEnterExitModShopEvent(player: Player,
-                                  /**
-                                   * The associated value for this event.
-                                   */
                                   val enterExit: Int,
-                                  /**
-                                   * The associated id of interior for this event.
-                                   */
                                   val interiorId: Int) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerEvent.kt
@@ -24,9 +24,7 @@ import net.gtaun.util.event.Event
  *
  * @author MK124
  * @author Marvin Haschker
+ *
+ * @property player The associated Player for this event.
  */
-open class PlayerEvent protected constructor(
-        /**
-         * The associated Player for this event.
-         */
-        val player: Player) : Event()
+open class PlayerEvent protected constructor(val player: Player) : Event()

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerFinishedDownloadingEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerFinishedDownloadingEvent.kt
@@ -1,5 +1,22 @@
+/**
+ * Copyright (C) 2017 MK124
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.gtaun.shoebill.event.player
 
 import net.gtaun.shoebill.entities.Player
 
+//TODO: Add documentation
 open class PlayerFinishedDownloadingEvent(player: Player, val virtualWorld: Int) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerGiveDamageEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerGiveDamageEvent.kt
@@ -25,21 +25,14 @@ import net.gtaun.shoebill.entities.Player
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerGiveDamage](https://wiki.sa-mp.com/wiki/OnPlayerGiveDamage)
+ *
+ * @property victim The associated victim for this event.
+ * @property amount The associated amount of damage for this event.
+ * @property weapon The associated used WeaponModel for this event.
+ * @property bodyPart The associated id of hit bodypart for this event.
  */
 class PlayerGiveDamageEvent(player: Player,
-                            /**
-                             * The associated victim for this event.
-                             */
                             val victim: Player,
-                            /**
-                             * The associated amount of damage for this event.
-                             */
                             val amount: Float,
-                            /**
-                             * The associated used WeaponModel for this event.
-                             */
                             val weapon: WeaponModel,
-                            /**
-                             * The associated id of hitted bodypart for this event.
-                             */
                             val bodyPart: Int) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerInteriorChangeEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerInteriorChangeEvent.kt
@@ -24,9 +24,7 @@ import net.gtaun.shoebill.entities.Player
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerInteriorChange](https://wiki.sa-mp.com/wiki/OnPlayerInteriorChange)
+ *
+ * @property oldInteriorId The associated old id of interior for this event.
  */
-class PlayerInteriorChangeEvent(player: Player,
-                                /**
-                                 * The associated old id of interior for this event.
-                                 */
-                                val oldInteriorId: Int) : PlayerEvent(player)
+class PlayerInteriorChangeEvent(player: Player, val oldInteriorId: Int) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerKeyStateChangeEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerKeyStateChangeEvent.kt
@@ -26,12 +26,10 @@ import net.gtaun.util.event.Disallowable
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerKeyStateChange](https://wiki.sa-mp.com/wiki/OnPlayerKeyStateChange)
+ *
+ * @property oldState The associated old PlayerKeyState for this event.
  */
-class PlayerKeyStateChangeEvent(player: Player,
-                                /**
-                                 * The associated old PlayerKeyState for this event.
-                                 */
-                                val oldState: PlayerKeyState) : PlayerEvent(player), Disallowable {
+class PlayerKeyStateChangeEvent(player: Player, val oldState: PlayerKeyState) : PlayerEvent(player), Disallowable {
     /**
      * The current response value
      */

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerKillEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerKillEvent.kt
@@ -25,13 +25,8 @@ import net.gtaun.shoebill.entities.Player
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerKill](https://wiki.sa-mp.com/wiki/OnPlayerKill)
+ *
+ * @property victim The associated victim for this event.
+ * @property weapon The associated used WeaponModel for this event.
  */
-class PlayerKillEvent(player: Player,
-                      /**
-                       * The associated victim for this event.
-                       */
-                      val victim: Player?,
-                      /**
-                       * The associated used WeaponModel for this event.
-                       */
-                      val weapon: WeaponModel) : PlayerEvent(player)
+class PlayerKillEvent(player: Player, val victim: Player?, val weapon: WeaponModel) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerPickupEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerPickupEvent.kt
@@ -25,9 +25,7 @@ import net.gtaun.shoebill.entities.Player
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerPickup](https://wiki.sa-mp.com/wiki/OnPlayerPickup)
+ *
+ * @property pickup The associated Pickup for this event.
  */
-class PlayerPickupEvent(player: Player,
-                        /**
-                         * The associated Pickup for this event.
-                         */
-                        val pickup: Pickup) : PlayerEvent(player)
+class PlayerPickupEvent(player: Player, val pickup: Pickup) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerRequestClassEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerRequestClassEvent.kt
@@ -25,12 +25,10 @@ import net.gtaun.util.event.Disallowable
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerRequestClass](https://wiki.sa-mp.com/wiki/OnPlayerRequestClass)
+ *
+ * @property classId The associated id of the requested class for this event.
  */
-class PlayerRequestClassEvent(player: Player,
-                              /**
-                               * The associated id of the requested class for this event.
-                               */
-                              val classId: Int) : PlayerEvent(player), Disallowable {
+class PlayerRequestClassEvent(player: Player, val classId: Int) : PlayerEvent(player), Disallowable {
     /**
      * The current response value
      */

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerSelectObjectEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerSelectObjectEvent.kt
@@ -25,9 +25,7 @@ import net.gtaun.shoebill.entities.SampObject
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerSelectObject](https://wiki.sa-mp.com/wiki/OnPlayerSelectObject)
+ *
+ * @property object The associated selected testing for this event.
  */
-class PlayerSelectObjectEvent(player: Player,
-                              /**
-                               * The associated selected testing for this event.
-                               */
-                              val `object`: SampObject) : PlayerEvent(player)
+class PlayerSelectObjectEvent(player: Player, val `object`: SampObject) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerSelectPlayerObjectEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerSelectPlayerObjectEvent.kt
@@ -22,12 +22,10 @@ import net.gtaun.shoebill.entities.PlayerObject
 /**
  * This event represents the OnPlayerSelectPlayerObject of Pawn.
  *
+ * @property object The associated selected PlayerObject for this event.
+ *
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerSelectPlayerObject](https://wiki.sa-mp.com/wiki/OnPlayerSelectPlayerObject)
  */
-class PlayerSelectPlayerObjectEvent(player: Player,
-                                    /**
-                                     * The associated selected PlayerObject for this event.
-                                     */
-                                    val `object`: PlayerObject) : PlayerEvent(player)
+class PlayerSelectPlayerObjectEvent(player: Player, val `object`: PlayerObject) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerStateChangeEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerStateChangeEvent.kt
@@ -25,13 +25,10 @@ import net.gtaun.shoebill.entities.Player
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerStateChange](https://wiki.sa-mp.com/wiki/OnPlayerStateChange)
+ *
+ * @property oldState The associated old PlayerState for this event.
+ * @property newState The associated new PlayerState for this event.
  */
 class PlayerStateChangeEvent(player: Player,
-                             /**
-                              * The associated old PlayerState for this event.
-                              */
                              val oldState: PlayerState,
-                             /**
-                              * The associated new PlayerState for this event.
-                              */
                              val newState: PlayerState = player.state) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerStreamInEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerStreamInEvent.kt
@@ -24,9 +24,7 @@ import net.gtaun.shoebill.entities.Player
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerStreamIn](https://wiki.sa-mp.com/wiki/OnPlayerStreamIn)
+ *
+ * @property forPlayer The associated Player for this event.
  */
-class PlayerStreamInEvent(player: Player,
-                          /**
-                           * The associated Player for this event.
-                           */
-                          val forPlayer: Player) : PlayerEvent(player)
+class PlayerStreamInEvent(player: Player, val forPlayer: Player) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerStreamOutEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerStreamOutEvent.kt
@@ -24,9 +24,7 @@ import net.gtaun.shoebill.entities.Player
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerStreamOut](https://wiki.sa-mp.com/wiki/OnPlayerStreamOut)
+ *
+ * @property forPlayer The associated Player for this event.
  */
-class PlayerStreamOutEvent(player: Player,
-                           /**
-                            * The associated Player for this event.
-                            */
-                           val forPlayer: Player) : PlayerEvent(player)
+class PlayerStreamOutEvent(player: Player, val forPlayer: Player) : PlayerEvent(player)

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerTakeDamageEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerTakeDamageEvent.kt
@@ -26,27 +26,20 @@ import net.gtaun.util.event.Disallowable
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerTakeDamage](https://wiki.sa-mp.com/wiki/OnPlayerTakeDamage)
+ *
+ * @property issuer The associated issuer for this event.
+ * @property amount The associated amount of damage for this event.
+ * @property weapon The associated used WeaponModel of issuer for this event.
+ * @property bodyPart The associated id of hitted bodypart for this event.
  */
 class PlayerTakeDamageEvent(player: Player,
-                            /**
-                             * The associated issuer for this event.
-                             */
                             val issuer: Player?,
-                            /**
-                             * The associated amount of damage for this event.
-                             */
                             val amount: Float,
-                            /**
-                             * The associated used WeaponModel of issuer for this event.
-                             */
                             val weapon: WeaponModel,
-                            /**
-                             * The associated id of hitted bodypart for this event.
-                             */
                             val bodyPart: Int) : PlayerEvent(player), Disallowable {
 
     /**
-     * The current response value
+     * The current response value.
      */
     var response: Int = 0
         private set

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerTextEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerTextEvent.kt
@@ -25,14 +25,12 @@ import net.gtaun.util.event.Disallowable
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerText](https://wiki.sa-mp.com/wiki/OnPlayerText)
+ *
+ * @property text The associated entered text for this event.
  */
-class PlayerTextEvent(player: Player,
-                      /**
-                       * The associated entered text for this event.
-                       */
-                      val text: String) : PlayerEvent(player), Disallowable {
+class PlayerTextEvent(player: Player, val text: String) : PlayerEvent(player), Disallowable {
     /**
-     * The current response value
+     * The current response value.
      */
     var response = 1
         private set

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerUpdateEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerUpdateEvent.kt
@@ -30,7 +30,7 @@ import net.gtaun.util.event.Disallowable
 class PlayerUpdateEvent(player: Player) : PlayerEvent(player), Disallowable {
 
     /**
-     * The current response value
+     * The current response value.
      */
     var response = 1
         private set

--- a/src/main/java/net/gtaun/shoebill/event/player/PlayerWeaponShotEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/player/PlayerWeaponShotEvent.kt
@@ -15,22 +15,19 @@ import net.gtaun.util.event.Disallowable
  * @author MK124
  * @author Marvin Haschker
  * @see [OnPlayerWeaponShot](https://wiki.sa-mp.com/wiki/OnPlayerWeaponShot)
+ *
+ * @property weapon The associated used WeaponModel for this event.
+ * @property hitType The associated BulletHitType for this event.
  */
 class PlayerWeaponShotEvent(player: Player,
-                            /**
-                             * The associated used WeaponModel for this event.
-                             */
                             val weapon: WeaponModel,
-                            /**
-                             * The associated BulletHitType for this event.
-                             */
                             val hitType: BulletHitType,
                             private val hitId: Int,
                             val position: Vector3D) : PlayerEvent(player), Disallowable {
 
 
     /**
-     * The current response value
+     * The current response value.
      */
     var response = 1
         private set

--- a/src/main/java/net/gtaun/shoebill/event/vehicle/VehicleSpawnEvent.kt
+++ b/src/main/java/net/gtaun/shoebill/event/vehicle/VehicleSpawnEvent.kt
@@ -19,6 +19,8 @@ package net.gtaun.shoebill.event.vehicle
 import net.gtaun.shoebill.entities.Vehicle
 
 /**
+ * This event wil be called when [vehicle] is spawned.
+ *
  * @author MK124
  */
 class VehicleSpawnEvent(vehicle: Vehicle) : VehicleEvent(vehicle)

--- a/src/main/java/net/gtaun/shoebill/resource/ResourceDescription.kt
+++ b/src/main/java/net/gtaun/shoebill/resource/ResourceDescription.kt
@@ -29,26 +29,19 @@ import java.util.jar.JarFile
 /**
  * @author MK124
  * @author Marvin Haschker
- */
-class ResourceDescription
-/**
- * Will create an instance of ResourceDescription with params.
- * @param type The Resourcetype
- * @param file The Location of the File to load.
- * @param classLoader The Classloader
+ *
+ * @constructor Will create an instance of ResourceDescription with params.
+ *
  * @throws ClassNotFoundException
  * @throws IOException
+ *
+ * @property type The resource type.
+ * @property file The location of the File to load.
+ * @property classLoader The [ClassLoader].
  */
+class ResourceDescription
 @Throws(ClassNotFoundException::class, IOException::class)
-constructor(
-        /**
-         * The ResourceType
-         */
-        val type: ResourceType,
-        /**
-         * The file of the [ResourceDescription] instance.
-         */
-        val file: File, private val classLoader: ClassLoader) {
+constructor(val type: ResourceType, val file: File, private val classLoader: ClassLoader) {
 
     /**
      * The class of the instance.

--- a/src/main/java/net/gtaun/shoebill/resource/ResourceType.kt
+++ b/src/main/java/net/gtaun/shoebill/resource/ResourceType.kt
@@ -19,13 +19,10 @@ package net.gtaun.shoebill.resource
 /**
  * @author MK124
  * @author Marvin Haschker
+ *
+ * @property configFilename The name of a resource configuration file.
  */
-enum class ResourceType constructor(
-        /**
-         * The Config File Name.
-         */
-        val configFilename: String) {
+enum class ResourceType(val configFilename: String) {
     PLUGIN("plugin.yml"),
-    GAMEMODE("gamemode.yml");
-
+    GAMEMODE("gamemode.yml")
 }


### PR DESCRIPTION
Mostly the documentation enhancement.  
Properties which values are assigned in the primary constructor had the following documentation form:
```kotlin
/**
 * Documentation of class Foo
 */
class Foo(
    /**
     * Documentation of property bar
     * This style often breaks the code highlighting. 
     */
    val bar: Int,
    /**
     * Documentation of property boo
     */
    val boo: Int
)
```
Now it looks like
```kotlin
/**
 * Documentation of class Foo
 *
 * @property bar Documentation of property bar
 * @property boo Documentation of property boo
 */
class Foo(
    val bar: Int,
    val boo: Int
)
```
Also, some code was using back-quoted names:
```kotlin
val `val`: Int
```
Back-quotes allow to use keywords as variable/property/class name, however, it's not recommended.